### PR TITLE
Remove mypy ignore annotations

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -21,13 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest numpy
-        pip install transformers==4.35.0
-        pip install types-requests
-        pip install mypy
-        pip install pyarrow-stubs==10.0.1.7
-        pip install safetensors
-        pip install .
+        pip install -r test-requirements.txt
         
     - name: Test with pytest
       run: |

--- a/fms-extras-requirements.txt
+++ b/fms-extras-requirements.txt
@@ -1,0 +1,8 @@
+# This requirement files can be used for development purposes, as it points to an
+# unreleased version (the main branch) for the ibm-fms package
+# It pins all other fms-extra dependencies to a specific version
+# for repeatable installs
+
+accelerate==0.26.1
+
+ibm-fms @ git+https://github.com/foundation-model-stack/foundation-model-stack@main

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,14 @@
+# This requirements file is for test jobs.
+# It pulls in general dependencies from fms-extras-requirements.txt
+# as well as test-only dependencies
+
+-r fms-extras-requirements.txt
+
+# Test tools
+mypy==1.8.0
+mypy-extensions==1.0.0
+pytest==8.0.0
+
+# Types packages
+pyarrow-stubs==10.0.1.7
+types-requests==2.31.0.20240125


### PR DESCRIPTION
This PR is made of two commits:

#### [Add requirement files for dev and test](https://github.com/foundation-model-stack/fms-extras/commit/984693d9783bdad519a7dd7a1673b8b68cb95448)

Add two requirement files:
- fms-extras-requirements.txt: it includes pinned dependencies except for ibm-fms that is taken from git, main branch
- test-requirements.txt: it includes packages for testing and it points to fms-extras-requirements.txt too
    
These are handy for test jobs, to install fms from main, so we don't depend on a release for testing purposes, at least for now.
Adapt the mypy workflow to take advantage of the new requirement files.

#### [Remove mypy ignore annotations](https://github.com/foundation-model-stack/fms-extras/commit/4aefe1603c79085da50fb72155fc846919433d47)

The fms project now includes a (partial) py.typed file, which allows mypy testing to pass for the fms-extras package.
    
Typing is incomplete on fms side in the hf package, so we continue to exclude the corresponding package on fms-extras to avoid failures. The extra testing uncovered two issues in `calico.py`:
    
- `fms_extras/models/calico.py:205: error: "list[int]" has no attribute "values"  [attr-defined]`
    
Fixed by removing the redundant values(), set(list[int]) works as it is.
    
- `fms_extras/models/calico.py:217: error: Incompatible types in assignment (expression has type Module, variable has type "CalicoBlock")  [assignment]`
    
Fixed by introducing an extra variable instead of overriding the original variable with an incompatible type.
 
Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>