### PR TITLE
Calico TP Embedding/Head fix

### DIFF
--- a/fms_extras/models/calico.py
+++ b/fms_extras/models/calico.py
@@ -185,7 +185,7 @@ class Calico(nn.Module):
         self.pad_id = self.config.pad_id
         self.max_expected_seq_len = self.config.max_expected_seq_len
 
-        shared = WordEmbedding(
+        self.shared = WordEmbedding(
             self.config.src_vocab_size,
             self.config.emb_dim,
             padding_idx=self.config.pad_id,
@@ -194,7 +194,6 @@ class Calico(nn.Module):
             tie_weights=True,
             bias=False,
         )
-        self.shared = self.distributed_strategy.distribute_module(shared)
 
         self.rot_emb = RotaryEmbedding(
             dim=self.config.emb_dim // self.config.nheads,


### PR DESCRIPTION
When trying to run tp with the calico model, the embedding/head run into issues as it is using tied heads, but WordEmbedding may need changes to support tp with tied heads. Removing tp wrapping from embedding for Calico, and will address the tp wrapping in a later PR