### PR TITLE
Speculative sampling

### DIFF
--- a/fms_extras/utils/generation.py
+++ b/fms_extras/utils/generation.py
@@ -429,6 +429,7 @@ def __generate_targets(
 
     # Composite greedy and non greedy outputs
     greedy = logits.argmax(-1)
+    samples = samples.to(dtype=greedy.dtype)
     return torch.where(do_sample[:, None, None], samples, greedy)
 
 
@@ -590,9 +591,9 @@ def speculative_generate(
         )
 
         if do_sample:
-            do_sample_vector = torch.ones(bsize, device=logits.device)
+            do_sample_vector = torch.ones(bsize, device=logits.device, dtype=torch.bool)
         else:
-            do_sample_vector = torch.zeros(bsize, device=logits.device)
+            do_sample_vector = torch.zeros(bsize, device=logits.device, dtype=torch.bool)
         next_vals = __generate_targets(
             logits, do_sample_vector, temperature=temperature, top_k=top_k
         )

--- a/fms_extras/utils/generation.py
+++ b/fms_extras/utils/generation.py
@@ -593,7 +593,9 @@ def speculative_generate(
         if do_sample:
             do_sample_vector = torch.ones(bsize, device=logits.device, dtype=torch.bool)
         else:
-            do_sample_vector = torch.zeros(bsize, device=logits.device, dtype=torch.bool)
+            do_sample_vector = torch.zeros(
+                bsize, device=logits.device, dtype=torch.bool
+            )
         next_vals = __generate_targets(
             logits, do_sample_vector, temperature=temperature, top_k=top_k
         )

--- a/fms_extras/utils/generation.py
+++ b/fms_extras/utils/generation.py
@@ -429,8 +429,7 @@ def __generate_targets(
 
     # Composite greedy and non greedy outputs
     greedy = logits.argmax(-1)
-    mask = do_sample[:, None, None].int()
-    return samples * mask + (1 - mask) * greedy
+    return torch.where(do_sample[:, None, None], samples, greedy)
 
 
 def speculative_generate(

--- a/fms_extras/utils/generation.py
+++ b/fms_extras/utils/generation.py
@@ -377,14 +377,14 @@ def __extract_decode_output(
 
 
 def __generate_targets(
-    logits: torch.Tensor, temperature: int = 1, top_k: int = 5, do_sample: bool = False
+    logits: torch.Tensor, temperature: float = 1.0, top_k: int = 5, do_sample: bool = False
 ) -> torch.Tensor:
     if not do_sample:
         return logits.argmax(-1)
 
     # Get sample distributions
     logits = logits / temperature
-    v, _ = logits.topk(logits, top_k)
+    v, _ = logits.topk(top_k)
     logits[logits < v[:, :, :, [-1]]] = -float("inf")
     probs = logits.softmax(-1)  # b k 1+h v
 

--- a/scripts/paged_speculative_inference.py
+++ b/scripts/paged_speculative_inference.py
@@ -107,9 +107,7 @@ parser.add_argument(
     help="degree of smoothing for sampling distribution (ignored if do_sample=False)",
 )
 parser.add_argument(
-    "--do_sample",
-    action="store_true",
-    help="enable non-greedy generation"
+    "--do_sample", action="store_true", help="enable non-greedy generation"
 )
 
 args = parser.parse_args()
@@ -251,7 +249,7 @@ def infer(ids, warmup):
             cudagraphs=cudagraphs,
             do_sample=args.do_sample,
             temperature=args.temperature,
-            top_k=args.top_k
+            top_k=args.top_k,
         )
     else:
         result, n_steps, ttft, generated_token_time_out = paged_generate(
@@ -264,7 +262,7 @@ def infer(ids, warmup):
             cudagraphs=cudagraphs,
             do_sample=args.do_sample,
             temperature=args.temperature,
-            top_k=args.top_k
+            top_k=args.top_k,
         )
     if not warmup:
         total_tokens = 0


### PR DESCRIPTION
Implements simple speculative sampling via candidate-consistent ground-truth sampling. See #12 for a discussion on implementation details and why this is needed in the first place.

- Add `__generate_targets()` function, implementing both greedy and non-greedy selection
- Enable sampling in `speculative_generate()`
- Support temperature and top_k sampling as in non-speculative generate
- Allow user to set these as arguments in the `paged_speculative_inference.py` demo script

Notably, for low temperature and top_k, we anecdotally observe no reduction in speculator performance compared to the greedy case!