### PR TITLE
Add speculator weight tying

### DIFF
--- a/fms_extras/models/speculator.py
+++ b/fms_extras/models/speculator.py
@@ -32,9 +32,25 @@ class MLPSpeculator(nn.Module):
         Number of entries in the tokenizer associated with the base model.
     n_predict : int
         Number of heads / number of tokens to guess ahead. Model size and speed scale with this value.
+    tie_emb : bool
+        If true, use a single set of embedding weights for every model head/stage
+    tie_head : bool
+        If true, use a single set of prediction weights for every model head/stage
+    tie_transitions : bool
+        If true, use a single set of internal projection weights for every model head/stage after the first.
+        The initial projection from the base model may have a different size, so that stays separate.
     """
 
-    def __init__(self, emb_dim=4096, inner_dim=0, vocab_size=32000, n_predict=3):
+    def __init__(
+        self,
+        emb_dim=4096,
+        inner_dim=0,
+        vocab_size=32000,
+        n_predict=3,
+        tie_emb=False,
+        tie_head=False,
+        tie_transition=False,
+    ):
         super().__init__()
         self.n_predict = n_predict
         self.emb_dim = emb_dim
@@ -65,6 +81,26 @@ class MLPSpeculator(nn.Module):
         self.state_weight = 0.5 ** (0.5 / n_predict)
         self.emb_weight = math.sqrt(1 - self.state_weight**2)
         self.activation = nn.GELU()
+
+        # Handle weight tying as specified
+        if tie_emb:
+            assert n_predict > 1, "You cannot tie embeddings when only 1 exists"
+            for emb in self.emb:
+                emb.weight = self.emb[0].weight
+        if tie_head:
+            assert n_predict > 1, "You cannot tie heads when only 1 exists"
+            for head in self.head:
+                head.weight = self.head[0].weight
+        if tie_transition:
+            assert (
+                n_predict > 2
+            ), "You cannot tie internal transitions when only 1 internal transition exists"
+            for ln in self.ln:
+                ln.weight = self.ln[0].weight
+                ln.bias = self.ln[0].bias
+            # Since first proj has different size, allow different initial proj from base into model
+            for i in range(2, n_predict):
+                self.proj[i].weight = self.proj[1].weight
 
     def reset_parameters(self):
         for m in self.modules():


### PR DESCRIPTION
Adds options for tying speculator head, embedding, and transition weights across stages. Parameter count responds as expected (decreasing when weights are tied). Setting all three options to True converts the MLP speculator into a fully recurrent model (with one separate initial projection from the base model into the speculator). These options are currently NOT hooked into existing scripts. Default behavior is unchanged.