### PR TITLE
Make torch versioning slightly stricter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "ninja",
     "packaging",
     "setuptools >= 49.4.0",
-    "torch ~= 2.2",
+    "torch ~= 2.2.0",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -2,5 +2,5 @@
 ninja
 packaging
 setuptools>=49.4.0
-torch~=2.2
+torch~=2.2.0
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Used to install pinned dependencies
 # Useful for dev/test jobs caches
 # Must be kept in sync with setup.py
-torch ~= 2.2 # This is what is installed in CI today
+torch ~= 2.2.0 # This is what is installed in CI today
 ibm-fms >= 0.0.4
 transformers >= 4.35.0
 accelerate >= 0.26.1


### PR DESCRIPTION
The current versioning:
```
torch~=2.2
```
is allowing `torch==2.3.0` to get pulled in when building `fms-extras` which is not compatible with the version we are using within TGIS today (2.2.1). I do not think this is the expected/desired behaviour. 

I would propose we change it to `torch~=2.2.0` which means that both `2.2.1` and `2.2.2` would be fine, but not `2.3.0`. 