### PR TITLE
Speculator wt init fix

### DIFF
--- a/fms_extras/models/speculator.py
+++ b/fms_extras/models/speculator.py
@@ -108,7 +108,7 @@ class MLPSpeculator(nn.Module):
     def reset_parameters(self):
         for m in self.modules():
             if isinstance(m, nn.Embedding) or isinstance(m, nn.Linear):
-                nn.init.trunc_normal_(m.weight, 0, 1 / math.sqrt(self.inner_dim))
+                nn.init.normal_(m.weight, 0, 1 / math.sqrt(self.inner_dim))
             elif isinstance(m, LayerNormParameterized) and hasattr(m, "weight"):
                 m.weight.data.fill_(1)
                 m.bias.data.zero_()
@@ -290,9 +290,9 @@ def flatten_batch(inp: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.
     batch_offset = 0
     # Generate the flatten/unflatten maps
     for b, candidate_set in enumerate(inp_list):
-        lineages: Dict[
-            Tuple[List[int]], int
-        ] = {}  # Prefix : n unique prefixes observed so far
+        lineages: Dict[Tuple[List[int]], int] = (
+            {}
+        )  # Prefix : n unique prefixes observed so far
         for k, candidate in enumerate(candidate_set):
             for n in range(len(candidate)):
                 lineage = tuple(candidate[: n + 1])

--- a/fms_extras/models/speculator.py
+++ b/fms_extras/models/speculator.py
@@ -290,9 +290,9 @@ def flatten_batch(inp: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.
     batch_offset = 0
     # Generate the flatten/unflatten maps
     for b, candidate_set in enumerate(inp_list):
-        lineages: Dict[Tuple[List[int]], int] = (
-            {}
-        )  # Prefix : n unique prefixes observed so far
+        lineages: Dict[
+            Tuple[List[int]], int
+        ] = {}  # Prefix : n unique prefixes observed so far
         for k, candidate in enumerate(candidate_set):
             for n in range(len(candidate)):
                 lineage = tuple(candidate[: n + 1])

--- a/fms_extras/modules/attention.py
+++ b/fms_extras/modules/attention.py
@@ -348,8 +348,8 @@ class TPPagedMultiHeadAttention(PagedMultiHeadAttention, TPModule):
         # if use_cache=True, we return the hidden_state as well as the kv cache.
         # We only reduce the output, and keep the cache thread-local
         if use_cache:
-            out = reduce_from_tensor_model_parallel_region(out_par[0])
+            out = reduce_from_tensor_model_parallel_region(out_par[0], self.world_size)
             return out, out_par[1]
         else:
-            out = reduce_from_tensor_model_parallel_region(out_par)
+            out = reduce_from_tensor_model_parallel_region(out_par, self.world_size)
             return out

--- a/fms_extras/utils/cache/paged.py
+++ b/fms_extras/utils/cache/paged.py
@@ -263,7 +263,7 @@ class PagedAttnKernel(ir.FallbackKernel):
                 tensor_args,
                 non_tensor_args,
                 unflatten_args,
-            ) = cls.process_kernel(kernel, *args, **kwargs)
+            ) = cls.process_kernel(kernel, *args, **kwargs)  # type: ignore
         for tensor_arg in tensor_args:
             tensor_arg.realize()
 

--- a/fms_extras/utils/cache/paged.py
+++ b/fms_extras/utils/cache/paged.py
@@ -263,7 +263,9 @@ class PagedAttnKernel(ir.FallbackKernel):
                 tensor_args,
                 non_tensor_args,
                 unflatten_args,
-            ) = cls.process_kernel(kernel, *args, **kwargs)  # type: ignore
+            ) = cls.process_kernel(
+                kernel, *args, **kwargs
+            )  # type: ignore
         for tensor_arg in tensor_args:
             tensor_arg.realize()
 


### PR DESCRIPTION
Fixes weird weight initialization issue which was causing high loss values during speculator training. Probably arises from a strange interaction between FSDP and `nn.init.trunc_normal_()`